### PR TITLE
Add support for Python 3.2 and 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,14 @@
 import os
 import sys
 
+py_version = sys.version_info[:2]
+
+if py_version < (2, 6):
+    raise RuntimeError(
+        'On Python 2, supervisor-serialrestart requires Python 2.6 or later')
+elif (3, 0) < py_version < (3, 2):
+    raise RuntimeError(
+        'On Python 3, supervisor-serialrestart requires Python 3.2 or later')
 
 try:
     from setuptools import setup
@@ -21,7 +29,7 @@ setup(
     name='supervisor-serialrestart',
     version='0.1.1',
     description='Adds serialrestart command to Supervisor.',
-    long_description=readme
+    long_description=readme,
     author='Sven Richter',
     author_email='native2k@gmail.com',
     url='https://github.com/native2k/supervisor-serialrestart',
@@ -44,6 +52,7 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
     ],
     test_suite='tests.run_tests.run_all',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -11,8 +11,9 @@ class TestPlugin(TestCase):
         self._supervisorctl('start all')
 
     def _supervisorctl(self, cmd, config_file=CONFIG_FILE):
-        out = Popen('supervisorctl --configuration="%s" %s' % (config_file, cmd), shell=True, stdout=PIPE).stdout.read()
-        print out
+        c = 'supervisorctl --configuration="%s" %s' % (config_file, cmd)
+        out = Popen(c, shell=True, stdout=PIPE).stdout.read().decode("utf-8")
+        print(out)
         return out
 
     def test_serialrestart_empty(self):


### PR DESCRIPTION
There is now a branch of Supervisor that supports Python 2 and 3. It is planned to be the next major release version. These changes get the supervisor-serialrestart tests passing on Python 3. 

A final step would be to add 3.2 and 3.3 to your tox and travis configs.  I did not do that because there is not yet a release version of Supervisor that installs on Python 3. If you have the Python 3 branch of Supervisor installed in your environment, and you remove "supervisor" from requirements.txt, the tests will pass.
